### PR TITLE
add support for XML files without enums/commands

### DIFF
--- a/generator/datasource.ts
+++ b/generator/datasource.ts
@@ -96,9 +96,9 @@ export interface MessageDef {
 }
 
 export interface Input {
-  readonly enumDefs: EnumDef[] & Pipeable<EnumDef[]>
+  readonly enumDefs?: EnumDef[] & Pipeable<EnumDef[]>
   readonly messageDefs: MessageDef[] & Pipeable<MessageDef[]>
-  readonly commandTypeDefs: CommandTypeDef[] & Pipeable<CommandTypeDef[]>
+  readonly commandTypeDefs?: CommandTypeDef[] & Pipeable<CommandTypeDef[]>
 }
 
 export class XmlDataSource {
@@ -117,7 +117,10 @@ export class XmlDataSource {
     return { enumDefs, messageDefs, commandTypeDefs }
   }
 
-  private readEnumDefs(mavlink: any): EnumDef[] & Pipeable<EnumDef[]> {
+  private readEnumDefs(mavlink: any): EnumDef[] & Pipeable<EnumDef[]> | undefined {
+    // If enums are empty, the parameter below becomes undefined and throws an error, so we check for that
+    if(mavlink.enums[0].enum === undefined) return undefined;
+
     // read raw values from the source XML definition
     const result = mavlink.enums[0].enum.map((xml: any) => ({
       name: makeClassName(xml.$.name),
@@ -270,7 +273,10 @@ export class XmlDataSource {
     return result
   }
 
-  private readCommandDefs(enums: EnumDef[]) {
+  private readCommandDefs(enums?: EnumDef[]) {
+    // Since commands are inside of enums, no enums means no commands
+    if(enums === undefined) return undefined;
+
     const result = (enums.find(e => e.name === 'MavCmd')?.values || [])
       .map(command => ({
         ...command,

--- a/generator/generators.ts
+++ b/generator/generators.ts
@@ -671,7 +671,10 @@ export function generateMagicNumbers(magicNumbers: Record<string, number>) {
   ].join('\n') + '\n'
 }
 
-function processEnums(output: Writer, enumDefs: EnumDef[] & Pipeable<EnumDef[]>) {
+function processEnums(output: Writer, enumDefs?: EnumDef[] & Pipeable<EnumDef[]>) {
+  // This prevents failure for the xml files without enums
+  if(enumDefs === undefined) return undefined;
+
   const enums = enumDefs
     // update descriptions to be multiline strings with a maximum width
     .pipe(enums => enums.map(entry => ({
@@ -718,7 +721,10 @@ function processMessages(output: Writer, messageDefs: MessageDef[] & Pipeable<Me
   return messages
 }
 
-function processCommands(output: Writer, moduleName: string, commandTypeDefs: CommandTypeDef[] & Pipeable<CommandTypeDef[]>) {
+function processCommands(output: Writer, moduleName: string, commandTypeDefs?: CommandTypeDef[] & Pipeable<CommandTypeDef[]>) {
+  // This prevents failure for the xml files without commands
+  if(commandTypeDefs === undefined) return undefined;
+
   const commands = commandTypeDefs
     .pipe(commands => commands.map(command => ({
       ...command,
@@ -738,10 +744,14 @@ function processCommands(output: Writer, moduleName: string, commandTypeDefs: Co
 
 export function processRegistries(output: Writer,
   messages: { id: string, name: string }[],
-  commands: { name: string, field: string }[],
+  commands?: { name: string, field: string }[],
 ) {
   generateMessageRegistry(output, messages)
-  generateCommandRegistry(output, commands)
+
+  // If there are no commands, do not generate registry
+  if(commands !== undefined) {
+    generateCommandRegistry(output, commands)
+  }
 }
 
 export async function generateAll(input: string, output: Writer, moduleName: string = '') {


### PR DESCRIPTION
This was working fine while we were using the XML file with its full potential, but when we were creating a new XML without any enum fields, we've encountered an error that said

```
Cannot read "map" of undefined
mavlink.enums[0].enum.map((xml: any) => ({
```

So we've come up with this solution